### PR TITLE
Improve cursor logic, emoji handling, canonicality, and tests

### DIFF
--- a/diff.d.ts
+++ b/diff.d.ts
@@ -1,0 +1,20 @@
+declare function diff(
+    text1: string,
+    text2: string,
+    cursorPos?: number | diff.CursorInfo
+): diff.Diff[];
+
+declare namespace diff {
+    type Diff = [-1 | 0 | 1, string];
+
+    const DELETE: -1;
+    const INSERT: 1;
+    const EQUAL: 0;
+
+    interface CursorInfo {
+        oldRange: { index: number; length: number };
+        newRange: { index: number; length: number };
+    }
+}
+
+export = diff;

--- a/diff.js
+++ b/diff.js
@@ -108,7 +108,7 @@ function diff_compute_(text1, text2) {
   var longtext = text1.length > text2.length ? text1 : text2;
   var shorttext = text1.length > text2.length ? text2 : text1;
   var i = longtext.indexOf(shorttext);
-  if (i != -1) {
+  if (i !== -1) {
     // Shorter text is inside the longer text (speedup).
     diffs = [
       [DIFF_INSERT, longtext.substring(0, i)],
@@ -122,7 +122,7 @@ function diff_compute_(text1, text2) {
     return diffs;
   }
 
-  if (shorttext.length == 1) {
+  if (shorttext.length === 1) {
     // Single character string.
     // After the previous speedup, the character can't be an equality.
     return [[DIFF_DELETE, text1], [DIFF_INSERT, text2]];
@@ -177,7 +177,7 @@ function diff_bisect_(text1, text2) {
   var delta = text1_length - text2_length;
   // If the total number of characters is odd, then the front path will collide
   // with the reverse path.
-  var front = (delta % 2 != 0);
+  var front = (delta % 2 !== 0);
   // Offsets for start and end of k loop.
   // Prevents mapping of space beyond the grid.
   var k1start = 0;
@@ -189,7 +189,7 @@ function diff_bisect_(text1, text2) {
     for (var k1 = -d + k1start; k1 <= d - k1end; k1 += 2) {
       var k1_offset = v_offset + k1;
       var x1;
-      if (k1 == -d || (k1 != d && v1[k1_offset - 1] < v1[k1_offset + 1])) {
+      if (k1 === -d || (k1 !== d && v1[k1_offset - 1] < v1[k1_offset + 1])) {
         x1 = v1[k1_offset + 1];
       } else {
         x1 = v1[k1_offset - 1] + 1;
@@ -197,7 +197,7 @@ function diff_bisect_(text1, text2) {
       var y1 = x1 - k1;
       while (
         x1 < text1_length && y1 < text2_length &&
-        text1.charAt(x1) == text2.charAt(y1)
+        text1.charAt(x1) === text2.charAt(y1)
       ) {
         x1++;
         y1++;
@@ -211,7 +211,7 @@ function diff_bisect_(text1, text2) {
         k1start += 2;
       } else if (front) {
         var k2_offset = v_offset + delta - k1;
-        if (k2_offset >= 0 && k2_offset < v_length && v2[k2_offset] != -1) {
+        if (k2_offset >= 0 && k2_offset < v_length && v2[k2_offset] !== -1) {
           // Mirror x2 onto top-left coordinate system.
           var x2 = text1_length - v2[k2_offset];
           if (x1 >= x2) {
@@ -226,7 +226,7 @@ function diff_bisect_(text1, text2) {
     for (var k2 = -d + k2start; k2 <= d - k2end; k2 += 2) {
       var k2_offset = v_offset + k2;
       var x2;
-      if (k2 == -d || (k2 != d && v2[k2_offset - 1] < v2[k2_offset + 1])) {
+      if (k2 === -d || (k2 !== d && v2[k2_offset - 1] < v2[k2_offset + 1])) {
         x2 = v2[k2_offset + 1];
       } else {
         x2 = v2[k2_offset - 1] + 1;
@@ -234,7 +234,7 @@ function diff_bisect_(text1, text2) {
       var y2 = x2 - k2;
       while (
         x2 < text1_length && y2 < text2_length &&
-        text1.charAt(text1_length - x2 - 1) == text2.charAt(text2_length - y2 - 1)
+        text1.charAt(text1_length - x2 - 1) === text2.charAt(text2_length - y2 - 1)
       ) {
         x2++;
         y2++;
@@ -248,7 +248,7 @@ function diff_bisect_(text1, text2) {
         k2start += 2;
       } else if (!front) {
         var k1_offset = v_offset + delta - k2;
-        if (k1_offset >= 0 && k1_offset < v_length && v1[k1_offset] != -1) {
+        if (k1_offset >= 0 && k1_offset < v_length && v1[k1_offset] !== -1) {
           var x1 = v1[k1_offset];
           var y1 = v_offset + x1 - k1_offset;
           // Mirror x2 onto top-left coordinate system.
@@ -402,7 +402,7 @@ function diff_halfMatch_(text1, text2) {
     var j = -1;
     var best_common = '';
     var best_longtext_a, best_longtext_b, best_shorttext_a, best_shorttext_b;
-    while ((j = shorttext.indexOf(seed, j + 1)) != -1) {
+    while ((j = shorttext.indexOf(seed, j + 1)) !== -1) {
       var prefixLength = diff_commonPrefix(
         longtext.substring(i), shorttext.substring(j));
       var suffixLength = diff_commonSuffix(
@@ -464,6 +464,7 @@ function diff_halfMatch_(text1, text2) {
  * Reorder and merge like edit sections.  Merge equalities.
  * Any edit section can move as long as it doesn't cross an equality.
  * @param {Array} diffs Array of diff tuples.
+ * @param {boolean} fix_unicode Whether to normalize to a unicode-correct diff
  */
 function diff_cleanupMerge(diffs, fix_unicode) {
   diffs.push([DIFF_EQUAL, '']);  // Add a dummy entry at the end.
@@ -578,7 +579,7 @@ function diff_cleanupMerge(diffs, fix_unicode) {
             pointer = pointer - n + 2;
           }
         }
-        if (pointer !== 0 && diffs[pointer - 1][0] == DIFF_EQUAL) {
+        if (pointer !== 0 && diffs[pointer - 1][0] === DIFF_EQUAL) {
           // Merge this equality with the previous one.
           diffs[pointer - 1][1] += diffs[pointer][1];
           diffs.splice(pointer, 1);
@@ -603,11 +604,11 @@ function diff_cleanupMerge(diffs, fix_unicode) {
   pointer = 1;
   // Intentionally ignore the first and last element (don't need checking).
   while (pointer < diffs.length - 1) {
-    if (diffs[pointer - 1][0] == DIFF_EQUAL &&
-      diffs[pointer + 1][0] == DIFF_EQUAL) {
+    if (diffs[pointer - 1][0] === DIFF_EQUAL &&
+      diffs[pointer + 1][0] === DIFF_EQUAL) {
       // This is a single edit surrounded by equalities.
       if (diffs[pointer][1].substring(diffs[pointer][1].length -
-        diffs[pointer - 1][1].length) == diffs[pointer - 1][1]) {
+        diffs[pointer - 1][1].length) === diffs[pointer - 1][1]) {
         // Shift the edit over the previous equality.
         diffs[pointer][1] = diffs[pointer - 1][1] +
           diffs[pointer][1].substring(0, diffs[pointer][1].length -
@@ -674,22 +675,22 @@ function make_edit_splice(before, oldMiddle, newMiddle, after) {
 
 function find_cursor_edit_diff(oldText, newText, cursor_pos) {
   // note: this runs after equality check has ruled out exact equality
-  var oldSelection = typeof cursor_pos === 'number' ?
-    { index: cursor_pos, length: 0 } : cursor_pos.oldSelection;
-  var newSelection = typeof cursor_pos === 'number' ?
-    null : cursor_pos.newSelection;
+  var oldRange = typeof cursor_pos === 'number' ?
+    { index: cursor_pos, length: 0 } : cursor_pos.oldRange;
+  var newRange = typeof cursor_pos === 'number' ?
+    null : cursor_pos.newRange;
   // take into account the old and new selection to generate the best diff
   // possible for a text edit.  for example, a text change from "xxx" to "xx"
   // could be a delete or forwards-delete of any one of the x's, or the
   // result of selecting two of the x's and typing "x".
   var oldLength = oldText.length;
   var newLength = newText.length;
-  if (oldSelection.length === 0 && (newSelection === null || newSelection.length === 0)) {
+  if (oldRange.length === 0 && (newRange === null || newRange.length === 0)) {
     // see if we have an insert or delete before or after cursor
-    var oldCursor = oldSelection.index;
+    var oldCursor = oldRange.index;
     var oldBefore = oldText.slice(0, oldCursor);
     var oldAfter = oldText.slice(oldCursor);
-    var maybeNewCursor = newSelection ? newSelection.index : null;
+    var maybeNewCursor = newRange ? newRange.index : null;
     editBefore: {
       // is this an insert or delete right before oldCursor?
       var newCursor = oldCursor + newLength - oldLength;
@@ -736,11 +737,11 @@ function find_cursor_edit_diff(oldText, newText, cursor_pos) {
       return make_edit_splice(oldBefore, oldMiddle, newMiddle, oldSuffix);
     }
   }
-  if (oldSelection.length > 0 && newSelection && newSelection.length === 0) {
+  if (oldRange.length > 0 && newRange && newRange.length === 0) {
     replaceRange: {
       // see if diff could be a splice of the old selection range
-      var oldPrefix = oldText.slice(0, oldSelection.index);
-      var oldSuffix = oldText.slice(oldSelection.index + oldSelection.length);
+      var oldPrefix = oldText.slice(0, oldRange.index);
+      var oldSuffix = oldText.slice(oldRange.index + oldRange.length);
       var prefixLength = oldPrefix.length;
       var suffixLength = oldSuffix.length;
       if (newLength < prefixLength + suffixLength) {

--- a/diff.js
+++ b/diff.js
@@ -516,6 +516,7 @@ function diff_cleanupMerge(diffs, fix_unicode) {
                 text_delete = diffs[k][1] + text_delete;
                 k--;
               }
+              previous_equality = k;
             }
           }
           if (starts_with_pair_end(diffs[pointer][1])) {
@@ -532,7 +533,7 @@ function diff_cleanupMerge(diffs, fix_unicode) {
         }
         if (text_delete.length > 0 || text_insert.length > 0) {
           if (text_delete.length > 0 && text_insert.length > 0) {
-            // Factor out any common prefixies.
+            // Factor out any common prefixes.
             commonlength = diff_commonPrefix(text_insert, text_delete);
             if (commonlength !== 0) {
               if (previous_equality >= 0) {
@@ -555,17 +556,21 @@ function diff_cleanupMerge(diffs, fix_unicode) {
           }
           // Delete the offending records and add the merged ones.
           var n = count_insert + count_delete;
-          if (text_delete.length === 0) {
+          if (text_delete.length === 0 && text_insert.length === 0) {
+            diffs.splice(pointer - n, n);
+            pointer = pointer - n;
+          } else if (text_delete.length === 0) {
             diffs.splice(pointer - n, n, [DIFF_INSERT, text_insert]);
-            pointer = pointer - n + 2;
+            pointer = pointer - n + 1;
           } else if (text_insert.length === 0) {
             diffs.splice(pointer - n, n, [DIFF_DELETE, text_delete]);
-            pointer = pointer - n + 2;
+            pointer = pointer - n + 1;
           } else {
             diffs.splice(pointer - n, n, [DIFF_DELETE, text_delete], [DIFF_INSERT, text_insert]);
-            pointer = pointer - n + 3;
+            pointer = pointer - n + 2;
           }
-        } else if (pointer !== 0 && diffs[pointer - 1][0] == DIFF_EQUAL) {
+        }
+        if (pointer !== 0 && diffs[pointer - 1][0] == DIFF_EQUAL) {
           // Merge this equality with the previous one.
           diffs[pointer - 1][1] += diffs[pointer][1];
           diffs.splice(pointer, 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "fast-diff",
+  "version": "1.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "3.9.3",
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+      "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
+      "dev": true
+    },
+    "seedrandom": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
+      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Jason Chen <jhchen7@gmail.com>",
   "main": "diff.js",
   "devDependencies": {
-    "googlediff": "~0.1.0",
     "lodash": "~3.9.3",
     "seedrandom": "~2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "fast-diff",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Fast Javascript text diff",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "main": "diff.js",
+  "types": "diff.d.ts",
   "devDependencies": {
     "lodash": "~3.9.3",
     "seedrandom": "~2.4.0"
@@ -19,5 +20,7 @@
     "test": "node test.js"
   },
   "license": "Apache-2.0",
-  "keywords": ["diff"]
+  "keywords": [
+    "diff"
+  ]
 }

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ var diff = require('./diff.js');
 var ITERATIONS = 10000;
 var ALPHABET = 'GATTACA';
 var LENGTH = 100;
+var EMOJI_MAX_LENGTH = 50;
 
 var seed = Math.floor(Math.random() * 10000);
 var random = seedrandom(seed);
@@ -15,6 +16,10 @@ console.log('Running regression tests...');
   ['🔘🤘🔗🔗', '🔗🤗🤗__🤗🤘🤘🤗🔗🤘🔗'],
   ['🔗🤗🤗__🤗🤘🤘🤗🔗🤘🔗', '🤗🤘🔘'],
   ['🤘🤘🔘🔘_🔘🔗🤘🤗🤗__🔗🤘', '🤘🔘🤘🔗🤘🤘🔗🤗🤘🔘🔘'],
+  ['🤗🤘🤗🔘🤘🔘🤗_🤗🔗🤘🤗_🤘🔗🤗🤘🔗🤘🤘🤘🔗🤗🔗🔗🔗🤗_🤘🔗🤗🤗🔘🤗🤗🤘🤗',
+   '_🤗🤘_🤘🤘🔘🤗🔘🤘_🔘🤗🔗🔘🔗🤘🔗🤘🤗🔗🔗🔗🤘🔘_🤗🤘🤘🤘__🤘_🔘🤘🤘_🔗🤘🔘'],
+  ['🔗🤘🤗🔘🔘🤗', '🤘🤘🤘🤗🔘🔗🔗'],
+  ['🔘_🔗🔗🔗🤗🔗', '🤘🤗🔗🤗_🤘🔘_'],
 ].forEach(function (data) {
   var result = diff(data[0], data[1]);
   applyDiff(result, data[0], data[1]);
@@ -242,7 +247,7 @@ console.log('Generating emoji strings...');
 var emoji_strings = [];
 for (var i = 0; i <= ITERATIONS; ++i) {
   var letters = [];
-  var len = Math.floor(random() * 50);
+  var len = Math.floor(random() * EMOJI_MAX_LENGTH);
   for (var l = 0; l < len; ++l) {
     var letter = EMOJI_ALPHABET[Math.floor(random() * EMOJI_ALPHABET.length)];
     letters.push(letter);

--- a/test.js
+++ b/test.js
@@ -1,52 +1,49 @@
 var _ = require('lodash');
-var googlediff = require('googlediff');
 var seedrandom = require('seedrandom');
 var diff = require('./diff.js');
 
-googlediff = new googlediff();
-
-var ITERATIONS = 1000;
+var ITERATIONS = 10000;
 var ALPHABET = 'GATTACA';
 var LENGTH = 100;
 
 var seed = Math.floor(Math.random() * 10000);
 var random = seedrandom(seed);
 
+console.log('Running regression tests...');
+[
+  ['GAATAAAAAAAGATTAACAT', 'AAAAACTTGTAATTAACAAC'],
+  ['🔘🤘🔗🔗', '🔗🤗🤗__🤗🤘🤘🤗🔗🤘🔗'],
+  ['🔗🤗🤗__🤗🤘🤘🤗🔗🤘🔗', '🤗🤘🔘'],
+  ['🤘🤘🔘🔘_🔘🔗🤘🤗🤗__🔗🤘', '🤘🔘🤘🔗🤘🤘🔗🤗🤘🔘🔘'],
+].forEach(function (data) {
+  var result = diff(data[0], data[1]);
+  applyDiff(result, data[0], data[1]);
+});
+
 console.log('Running computing ' + ITERATIONS + ' diffs with seed ' + seed + '...');
 
 console.log('Generating strings...');
 var strings = [];
-for(var i = 0; i <= ITERATIONS; ++i) {
+for (var i = 0; i <= ITERATIONS; ++i) {
   var chars = [];
-  for(var l = 0; l < LENGTH; ++l) {
+  for (var l = 0; l < LENGTH; ++l) {
     var letter = ALPHABET.substr(Math.floor(random() * ALPHABET.length), 1);
     chars.push(letter);
   }
   strings.push(chars.join(''));
 }
 
-console.log('Running tests *without* cursor information...');
-for(var i = 0; i < ITERATIONS; ++i) {
-  var result = diff(strings[i], strings[i+1]);
-  var expected = googlediff.diff_main(strings[i], strings[i+1]);
-  if (!_.isEqual(result, expected)) {
-    console.log('Expected', expected);
-    console.log('Result', result);
-    throw new Error('Diff produced difference results.');
-  }
+console.log('Running fuzz tests *without* cursor information...');
+for (var i = 0; i < ITERATIONS; ++i) {
+  var result = diff(strings[i], strings[i + 1]);
+  applyDiff(result, strings[i], strings[i + 1]);
 }
 
-console.log('Running tests *with* cursor information');
-for(var i = 0; i < ITERATIONS; ++i) {
+console.log('Running fuzz tests *with* cursor information');
+for (var i = 0; i < ITERATIONS; ++i) {
   var cursor_pos = Math.floor(random() * strings[i].length + 1);
-  var diffs = diff(strings[i], strings[i+1], cursor_pos);
-  var patch = googlediff.patch_make(strings[i], strings[i+1], diffs);
-  var expected = googlediff.patch_apply(patch, strings[i])[0];
-  if (expected !== strings[i+1]) {
-    console.log('Expected', expected);
-    console.log('Result', strings[i+1]);
-    throw new Error('Diff produced difference results.');
-  }
+  var diffs = diff(strings[i], strings[i + 1], cursor_pos);
+  applyDiff(diffs, strings[i], strings[i + 1]);
 }
 
 function parseDiff(str) {
@@ -150,8 +147,8 @@ console.log('Running cursor tests');
   var oldText = data[0];
   var newText = data[2];
   var oldSelection = typeof data[1] === 'number' ?
-  { index: data[1], length: 0 } :
-  { index: data[1][0], length: data[1][1] - data[1][0] };
+    { index: data[1], length: 0 } :
+    { index: data[1][0], length: data[1][1] - data[1][0] };
   var newSelection = typeof data[3] === 'number' ?
     { index: data[3], length: 0 } :
     data[3] === null ? null : { index: data[3][0], length: data[3][1] - data[3][0] };
@@ -212,31 +209,121 @@ function doCursorTest(oldText, newText, selectionInfo, expected) {
 }
 
 console.log('Running emoji tests');
-(function() {
-  var result = diff('🐶', '🐯');
-  var expected = parseDiff('-🐶+🐯');
-  if (!_.isEqual(result, expected)) {
-    console.log(result, '!==', expected);
-    throw new Error('Emoji simple case test failed');
-  }
-})();
+[
+  ['🐶', '🐯', '-🐶+🐯'],
+  ['👨🏽', '👩🏽', '-👨+👩=🏽'],
+  ['👩🏼', '👩🏽', '=👩-🏼+🏽'],
 
-(function() {
-  var result = diff('👨🏽', '👩🏽');
-  var expected = parseDiff('-👨+👩=🏽');
-  if (!_.isEqual(result, expected)) {
-    console.log(result, '!==', expected);
-    throw new Error('Emoji before case test failed');
-  }
-})();
+  ['🍏🍎', '🍎', '-🍏=🍎'],
+  ['🍎', '🍏🍎', '+🍏=🍎'],
 
-(function() {
-  var result = diff('👩🏼', '👩🏽');
-  var expected = parseDiff('=👩-🏼+🏽');
+].forEach(function (data) {
+  var oldText = data[0];
+  var newText = data[1];
+  var expected = parseDiff(data[2]);
+  doEmojiTest(oldText, newText, expected);
+  doEmojiTest('x' + oldText, 'x' + newText, diffPrepend(expected, 'x'));
+  doEmojiTest(oldText + 'x', newText + 'x', diffAppend(expected, 'x'));
+});
+
+function doEmojiTest(oldText, newText, expected) {
+  var result = diff(oldText, newText);
   if (!_.isEqual(result, expected)) {
+    console.log(oldText, newText, expected);
     console.log(result, '!==', expected);
-    throw new Error('Emoji after case test failed');
+    throw new Error('Emoji simple test case failed');
   }
-})();
+}
+
+// emojis chosen to share high and low surrogates!
+var EMOJI_ALPHABET = ['_', '🤗', '🔗', '🤘', '🔘'];
+
+console.log('Generating emoji strings...');
+var emoji_strings = [];
+for (var i = 0; i <= ITERATIONS; ++i) {
+  var letters = [];
+  var len = Math.floor(random() * 50);
+  for (var l = 0; l < len; ++l) {
+    var letter = EMOJI_ALPHABET[Math.floor(random() * EMOJI_ALPHABET.length)];
+    letters.push(letter);
+  }
+  emoji_strings.push(letters.join(''));
+}
+
+console.log('Running emoji fuzz tests...');
+for (var i = 0; i < ITERATIONS; ++i) {
+  var oldText = emoji_strings[i];
+  var newText = emoji_strings[i + 1];
+  var result = diff(oldText, newText);
+  applyDiff(result, oldText, newText);
+}
+
+// Applies a diff to text, throwing an error if diff is invalid or incorrect
+function applyDiff(diffs, text, expectedResult) {
+  var pos = 0;
+  function throwError(message) {
+    console.log(diffs, text, expectedResult);
+    throw new Error(message);
+  }
+  function expect(expected) {
+    var found = text.substr(pos, expected.length);
+    if (found !== expected) {
+      throwError('Expected "' + expected + '", found "' + found + '"');
+    }
+  }
+  var result = '';
+  var inserts_since_last_equality = 0;
+  var deletes_since_last_equality = 0;
+  for (var i = 0; i < diffs.length; i++) {
+    var d = diffs[i];
+    if (!d[1]) {
+      throwError('Empty tuple in diff')
+    }
+    var firstCharCode = d[1].charCodeAt(0);
+    var lastCharCode = d[1].slice(-1).charCodeAt(0);
+    if (firstCharCode >= 0xDC00 && firstCharCode <= 0xDFFF ||
+      lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) {
+        throwError('Bad unicode diff tuple')
+    }
+    switch (d[0]) {
+      case diff.EQUAL:
+        if (i !== 0 && !inserts_since_last_equality && !deletes_since_last_equality) {
+          throwError('two consecutive equalities in diff');
+        }
+        inserts_since_last_equality = 0;
+        deletes_since_last_equality = 0;
+        expect(d[1]);
+        result += d[1];
+        pos += d[1].length;
+        break;
+      case diff.DELETE:
+        if (deletes_since_last_equality) {
+          throwError('multiple deletes between equalities')
+        }
+        if (inserts_since_last_equality) {
+          throwError('delete following insert in diff')
+        }
+        deletes_since_last_equality++;
+        expect(d[1]);
+        pos += d[1].length;
+        break
+      case diff.INSERT:
+        if (inserts_since_last_equality) {
+          throwError('multiple inserts between equalities')
+        }
+        inserts_since_last_equality++;
+        result += d[1];
+        break;
+    }
+  }
+  if (pos !== text.length) {
+    throwError('Diff did not consume entire input text');
+  }
+  if (result !== expectedResult) {
+    console.log(diffs, text, expectedResult, result);
+    throw new Error('Diff not correct')
+  }
+  return result;
+}
 
 console.log("Success!");

--- a/test.js
+++ b/test.js
@@ -151,23 +151,23 @@ console.log('Running cursor tests');
 ].forEach(function (data) {
   var oldText = data[0];
   var newText = data[2];
-  var oldSelection = typeof data[1] === 'number' ?
+  var oldRange = typeof data[1] === 'number' ?
     { index: data[1], length: 0 } :
     { index: data[1][0], length: data[1][1] - data[1][0] };
-  var newSelection = typeof data[3] === 'number' ?
+  var newRange = typeof data[3] === 'number' ?
     { index: data[3], length: 0 } :
     data[3] === null ? null : { index: data[3][0], length: data[3][1] - data[3][0] };
   var expected = parseDiff(data[4]);
-  if (newSelection === null && typeof data[1] !== 'number') {
+  if (newRange === null && typeof data[1] !== 'number') {
     throw new Error('invalid test case');
   }
-  var selectionInfo = newSelection === null ? data[1] : {
-    oldSelection: oldSelection,
-    newSelection: newSelection,
+  var cursorInfo = newRange === null ? data[1] : {
+    oldRange: oldRange,
+    newRange: newRange,
   };
-  doCursorTest(oldText, newText, selectionInfo, expected);
-  doCursorTest('x' + oldText, 'x' + newText, shiftSelectionInfo(selectionInfo, 1), diffPrepend(expected, 'x'));
-  doCursorTest(oldText + 'x', newText + 'x', selectionInfo, diffAppend(expected, 'x'));
+  doCursorTest(oldText, newText, cursorInfo, expected);
+  doCursorTest('x' + oldText, 'x' + newText, shiftCursorInfo(cursorInfo, 1), diffPrepend(expected, 'x'));
+  doCursorTest(oldText + 'x', newText + 'x', cursorInfo, diffAppend(expected, 'x'));
 });
 
 function diffPrepend(tuples, text) {
@@ -187,27 +187,27 @@ function diffAppend(tuples, text) {
   }
 }
 
-function shiftSelectionInfo(selectionInfo, amount) {
-  if (typeof selectionInfo === 'number') {
-    return selectionInfo + amount;
+function shiftCursorInfo(cursorInfo, amount) {
+  if (typeof cursorInfo === 'number') {
+    return cursorInfo + amount;
   } else {
     return {
-      oldSelection: {
-        index: selectionInfo.oldSelection.index + amount,
-        length: selectionInfo.oldSelection.length,
+      oldRange: {
+        index: cursorInfo.oldRange.index + amount,
+        length: cursorInfo.oldRange.length,
       },
-      newSelection: {
-        index: selectionInfo.newSelection.index + amount,
-        length: selectionInfo.newSelection.length,
+      newRange: {
+        index: cursorInfo.newRange.index + amount,
+        length: cursorInfo.newRange.length,
       },
     }
   }
 }
 
-function doCursorTest(oldText, newText, selectionInfo, expected) {
-  var result = diff(oldText, newText, selectionInfo);
+function doCursorTest(oldText, newText, cursorInfo, expected) {
+  var result = diff(oldText, newText, cursorInfo);
   if (!_.isEqual(result, expected)) {
-    console.log([oldText, newText, selectionInfo]);
+    console.log([oldText, newText, cursorInfo]);
     console.log(result, '!==', expected);
     throw new Error('cursor test failed');
   }

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var diff = require('./diff.js');
 
 googlediff = new googlediff();
 
-var ITERATIONS = 10000;
+var ITERATIONS = 1000;
 var ALPHABET = 'GATTACA';
 var LENGTH = 100;
 
@@ -49,13 +49,172 @@ for(var i = 0; i < ITERATIONS; ++i) {
   }
 }
 
+function parseDiff(str) {
+  if (!str) {
+    return [];
+  }
+  return str.split(/(?=[+\-=])/).map(function (piece) {
+    var symbol = piece.charAt(0);
+    var text = piece.slice(1);
+    return [
+      symbol === '+' ? diff.INSERT : symbol === '-' ? diff.DELETE : diff.EQUAL,
+      text
+    ]
+  });
+}
+
+console.log('Running cursor tests');
+[
+  ['', 0, '', null, ''],
+
+  ['', 0, 'a', null, '+a'],
+  ['a', 0, 'aa', null, '+a=a'],
+  ['a', 1, 'aa', null, '=a+a'],
+  ['aa', 0, 'aaa', null, '+a=aa'],
+  ['aa', 1, 'aaa', null, '=a+a=a'],
+  ['aa', 2, 'aaa', null, '=aa+a'],
+  ['aaa', 0, 'aaaa', null, '+a=aaa'],
+  ['aaa', 1, 'aaaa', null, '=a+a=aa'],
+  ['aaa', 2, 'aaaa', null, '=aa+a=a'],
+  ['aaa', 3, 'aaaa', null, '=aaa+a'],
+
+  ['a', 0, '', null, '-a'],
+  ['a', 1, '', null, '-a'],
+  ['aa', 0, 'a', null, '-a=a'],
+  ['aa', 1, 'a', null, '-a=a'],
+  ['aa', 2, 'a', null, '=a-a'],
+  ['aaa', 0, 'aa', null, '-a=aa'],
+  ['aaa', 1, 'aa', null, '-a=aa'],
+  ['aaa', 2, 'aa', null, '=a-a=a'],
+  ['aaa', 3, 'aa', null, '=aa-a'],
+
+  ['', 0, '', 0, ''],
+
+  ['', 0, 'a', 1, '+a'],
+  ['a', 0, 'aa', 1, '+a=a'],
+  ['a', 1, 'aa', 2, '=a+a'],
+  ['aa', 0, 'aaa', 1, '+a=aa'],
+  ['aa', 1, 'aaa', 2, '=a+a=a'],
+  ['aa', 2, 'aaa', 3, '=aa+a'],
+  ['aaa', 0, 'aaaa', 1, '+a=aaa'],
+  ['aaa', 1, 'aaaa', 2, '=a+a=aa'],
+  ['aaa', 2, 'aaaa', 3, '=aa+a=a'],
+  ['aaa', 3, 'aaaa', 4, '=aaa+a'],
+
+  ['a', 1, '', 0, '-a'],
+  ['aa', 1, 'a', 0, '-a=a'],
+  ['aa', 2, 'a', 1, '=a-a'],
+  ['aaa', 1, 'aa', 0, '-a=aa'],
+  ['aaa', 2, 'aa', 1, '=a-a=a'],
+  ['aaa', 3, 'aa', 2, '=aa-a'],
+
+  ['a', 1, '', 0, '-a'],
+  ['aa', 1, 'a', 0, '-a=a'],
+  ['aa', 2, 'a', 1, '=a-a'],
+  ['aaa', 1, 'aa', 0, '-a=aa'],
+  ['aaa', 2, 'aa', 1, '=a-a=a'],
+  ['aaa', 3, 'aa', 2, '=aa-a'],
+
+  // forward-delete
+  ['a', 0, '', 0, '-a'],
+  ['aa', 0, 'a', 0, '-a=a'],
+  ['aa', 1, 'a', 1, '=a-a'],
+  ['aaa', 0, 'aa', 0, '-a=aa'],
+  ['aaa', 1, 'aa', 1, '=a-a=a'],
+  ['aaa', 2, 'aa', 2, '=aa-a'],
+
+  ['bob', 0, 'bobob', null, '+bo=bob'],
+  ['bob', 1, 'bobob', null, '=b+ob=ob'],
+  ['bob', 2, 'bobob', null, '=bo+bo=b'],
+  ['bob', 3, 'bobob', null, '=bob+ob'],
+  ['bob', 0, 'bobob', 2, '+bo=bob'],
+  ['bob', 1, 'bobob', 3, '=b+ob=ob'],
+  ['bob', 2, 'bobob', 4, '=bo+bo=b'],
+  ['bob', 3, 'bobob', 5, '=bob+ob'],
+  ['bobob', 2, 'bob', null, '-bo=bob'],
+  ['bobob', 3, 'bob', null, '=b-ob=ob'],
+  ['bobob', 4, 'bob', null, '=bo-bo=b'],
+  ['bobob', 5, 'bob', null, '=bob-ob'],
+  ['bobob', 2, 'bob', 0, '-bo=bob'],
+  ['bobob', 3, 'bob', 1, '=b-ob=ob'],
+  ['bobob', 4, 'bob', 2, '=bo-bo=b'],
+  ['bobob', 5, 'bob', 3, '=bob-ob'],
+
+  ['bob', 1, 'b', null, '=b-ob'],
+
+  ['hello', [0, 5], 'h', 1, '-hello+h'],
+  ['yay', [0, 3], 'y', 1, '-yay+y'],
+  ['bobob', [1, 4], 'bob', 2, '=b-obo+o=b'],
+
+].forEach(function (data) {
+  var oldText = data[0];
+  var newText = data[2];
+  var oldSelection = typeof data[1] === 'number' ?
+  { index: data[1], length: 0 } :
+  { index: data[1][0], length: data[1][1] - data[1][0] };
+  var newSelection = typeof data[3] === 'number' ?
+    { index: data[3], length: 0 } :
+    data[3] === null ? null : { index: data[3][0], length: data[3][1] - data[3][0] };
+  var expected = parseDiff(data[4]);
+  if (newSelection === null && typeof data[1] !== 'number') {
+    throw new Error('invalid test case');
+  }
+  var selectionInfo = newSelection === null ? data[1] : {
+    oldSelection: oldSelection,
+    newSelection: newSelection,
+  };
+  doCursorTest(oldText, newText, selectionInfo, expected);
+  doCursorTest('x' + oldText, 'x' + newText, shiftSelectionInfo(selectionInfo, 1), diffPrepend(expected, 'x'));
+  doCursorTest(oldText + 'x', newText + 'x', selectionInfo, diffAppend(expected, 'x'));
+});
+
+function diffPrepend(tuples, text) {
+  if (tuples.length > 0 && tuples[0][0] === diff.EQUAL) {
+    return [[diff.EQUAL, text + tuples[0][1]]].concat(tuples.slice(1));
+  } else {
+    return [[diff.EQUAL, text]].concat(tuples);
+  }
+}
+
+function diffAppend(tuples, text) {
+  var lastTuple = tuples[tuples.length - 1];
+  if (lastTuple && lastTuple[0] === diff.EQUAL) {
+    return tuples.slice(0, -1).concat([[diff.EQUAL, lastTuple[1] + text]]);
+  } else {
+    return tuples.concat([[diff.EQUAL, text]]);
+  }
+}
+
+function shiftSelectionInfo(selectionInfo, amount) {
+  if (typeof selectionInfo === 'number') {
+    return selectionInfo + amount;
+  } else {
+    return {
+      oldSelection: {
+        index: selectionInfo.oldSelection.index + amount,
+        length: selectionInfo.oldSelection.length,
+      },
+      newSelection: {
+        index: selectionInfo.newSelection.index + amount,
+        length: selectionInfo.newSelection.length,
+      },
+    }
+  }
+}
+
+function doCursorTest(oldText, newText, selectionInfo, expected) {
+  var result = diff(oldText, newText, selectionInfo);
+  if (!_.isEqual(result, expected)) {
+    console.log([oldText, newText, selectionInfo]);
+    console.log(result, '!==', expected);
+    throw new Error('cursor test failed');
+  }
+}
+
 console.log('Running emoji tests');
 (function() {
   var result = diff('🐶', '🐯');
-  var expected = [
-    [diff.DELETE, '🐶'],
-    [diff.INSERT, '🐯'],
-  ];
+  var expected = parseDiff('-🐶+🐯');
   if (!_.isEqual(result, expected)) {
     console.log(result, '!==', expected);
     throw new Error('Emoji simple case test failed');
@@ -64,11 +223,7 @@ console.log('Running emoji tests');
 
 (function() {
   var result = diff('👨🏽', '👩🏽');
-  var expected = [
-    [diff.DELETE, '👨'],
-    [diff.INSERT, '👩'],
-    [diff.EQUAL, '🏽']
-  ];
+  var expected = parseDiff('-👨+👩=🏽');
   if (!_.isEqual(result, expected)) {
     console.log(result, '!==', expected);
     throw new Error('Emoji before case test failed');
@@ -77,11 +232,7 @@ console.log('Running emoji tests');
 
 (function() {
   var result = diff('👩🏼', '👩🏽');
-  var expected = [
-    [diff.EQUAL, '👩'],
-    [diff.DELETE, '🏼'],
-    [diff.INSERT, '🏽'],
-  ];
+  var expected = parseDiff('=👩-🏼+🏽');
   if (!_.isEqual(result, expected)) {
     console.log(result, '!==', expected);
     throw new Error('Emoji after case test failed');


### PR DESCRIPTION
This PR makes the following changes:

* Changes the behavior of the third, "cursor" argument of `diff(...)` in a roughly backwards-compatible way to 1) meet Quill's diffing needs for text editing, and 2) make it easier to return canonical diffs with correct unicode handling
  * Previously, this argument was always a number, representing the cursor position before the change.  While the exact behavior has never been specified, and was previously not unit-tested, the idea was that `diff('aaa', 'aa', 1)` would delete the first `a` (under the notion that the user positioned the cursor at position 1 and then backspaced), while `diff('aaa', 'aa', 2)` would delete the second `a`, and so on.  However, the implementation was flawed, and fixing it would have been very complex due to interactions with the diff optimizer.  It failed on documents as simple as `xaa` or `aax`.
  * The new implementation takes either a number or a structure with shape `{oldSelection: {index, length}, newSelection: {index, length}}` representing the selection range or text cursor (a range with length 0) before and after the change.  If a number is given, it represents the position of a zero-length `oldSelection`, with the `newSelection` being inferred.  Using selection ranges allows cases such as forward-delete and typing to replace a range of text to be taken into account.  The major difference from the old implementation when a number is given, besides working correctly on arbitrary splices, is that it only works if the entire diff is a splice at the cursor position.  It doesn't try to "fix up" the diff around the cursor position in the presence of other changes like the old implementation.  It seems unlikely that someone was using this argument and relying on that precise behavior.
  * Added a bunch of unit tests for the cursor argument
* Fix unicode/emoji handling to be fully valid and tested.  The previous code for fixing invalid emojis was not exhaustive.
* Improve canonicality of resulting diffs.
  * The previous implementation would sometimes include empty spans in the output!  This is a quirk of the original code from Google
  * The original code sought to ensure a certain pattern to the output spans, e.g. any two EQUAL spans with only INSERT and DELETE spans between them must have at least one INSERT or DELETE span, and at most one of each, and if there is one of each, the DELETE must come before the INSERT.  This pattern was disrupted by the handling of cursor position and unicode, and in fact all three concerns worked against each other.  By integrating unicode handling with the diff cleanup routine, this is no longer the case, and we can ensure good properties of the diff.
* I removed the tests that compare our diff output with the original Google code's diff output, and the dependency on googlediff.  Our diff output now diverges, even without emojis and without a cursor position, due to my insistence on eliminating empty spans from the output.  There is new test code that makes sure diffs are correct, e.g. that they are retaining or deleting all the old text, in order, and retaining or inserting all the new text, in order, in addition to checking canonicality.
* Minor formatting cleanups.  I kept to the original style of the code in many ways (e.g. using `var` and `function`).  I pretty much wrote in ES5 style, though I have not made sure the code is ES5 clean.  I did change `==` to `===` in a few places as a matter of style and changed some indentation so I could use my IDE's auto-formatter.